### PR TITLE
Feature/#796 edit security model in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,18 @@ This conflict causes the `@XmlRootElement` annotion to be missing from a number 
 
 In order to resolve this a custom binding file is added for SagDokumentIndeks, that specifies the `@XmlRootElement` for the classes that need it. This custom binding will not affect the resulting XML structure but allows the project to compile and XML to be properly serialized.
 
+## 7.0 Validation Tool
+
+To aid developers with the integration to [Sags- og Dokumentindeks (SF1470)](https://digitaliseringskataloget.dk/integration/sf1470), KOMBIT has developed a validation tool that can be used to validate the XML structure that must be specified as input in calls to the [Sags- og Dokumentindeks (SF1470)](https://digitaliseringskataloget.dk/integration/sf1470). The purpose of the tool is to help build and understand data structures.
+
+Briefly about the tool:
+
+- The tool takes the same XML structure as the corresponding operation in the integration as input.
+- The tool first performs schema validation, if there are errors, the entire schema error message is returned.
+- The tool validates mandatory fields according to the instructions found in the documents Use of the Case Object in the Common Municipal Case and Document Index and Use of the Document Index in the Common Municipal Case and Document Index
+- The tool returns detailed and informative error messages, including references to the place in the Instructions where the structure/requirements are described.
+
+The tool can be used without having made any premade service agreements. The tool can be called with the same input structure (both with and without Security Token) as existing operations in [Sags- og Dokumentindeks (SF1470)](https://digitaliseringskataloget.dk/integration/sf1470), by calling against the following endpoint: https://virtualize01.serviceplatformen.dk/testservice/SF1470-Validation/V61
 
 
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ The code examples demonstrate how to use the following services and operations:
 
 | Integration  | Service                       | Operations |
 | :--- |:------------------------------| :--- |
-| [Sags- og Dokumentindeks (SF1470)](https://digitaliseringskataloget.dk/integration/sf1470) | SagDokumentIndeksService v6.0 | Importer, Fremsoeg, Fjern |
+| [Klassifikation (SF1510)](https://digitaliseringskataloget.dk/integration/sf1510) | KlasseService v7.0            | Soeg, List |
 | [Organisation (SF1500)](https://digitaliseringskataloget.dk/integration/sf1500)  | VirksomhedService v6.0        | Soeg  |
 | [Organisation (SF1500)](https://digitaliseringskataloget.dk/integration/sf1500) | OrganisationService v6.0      | Soeg, Laes |
-| [Klassifikation (SF1510)](https://digitaliseringskataloget.dk/integration/sf1510) | KlasseService v7.0            | Soeg, List |
+| [Sags- og Dokumentindeks (SF1470)](https://digitaliseringskataloget.dk/integration/sf1470) | SagDokumentIndeksService v6.0 | Importer, Opdater (IN DEVELOPMENT) Fremsoeg, Fjern |
+| IN DEVELOPMENT [Ydelsesindeks  v6.0 (SF1490)](https://digitaliseringskataloget.dk/integration/sf1490) | YdelsesIndeksService v6.0 | Importer, Opdater, Fremsoeg, Fjern |
 
-Sags- og Dokumentindeks v5.0 use Liberty Basic Soap Binding and are called via Serviceplatformen. Organisation v6.0 and Klassifikation v6.0 uses the IDWS Binding (OIO IDWS SOAP profile) and is called directly, i.e. not via Serviceplatformen. The signing of the SOAP Envelope content has been simplified with OIOIDWS. The examples demonstrate how both security profiles can be used in the same context. Read more at [Digitaliseringskataloget](https://digitaliseringskataloget.dk/tekniske_betingelser/adgangsstyring-systemer)
+[Klassifikation v7.0 (SF1510)](https://digitaliseringskataloget.dk/integration/sf1510), [Organisation v6.0 (SF1500)](https://digitaliseringskataloget.dk/integration/sf1500), [Sags- og Dokumentindeks v6.0 (SF1470)](https://digitaliseringskataloget.dk/integration/sf1470) and [Ydelsesindeks  v6.0 (SF1490)](https://digitaliseringskataloget.dk/integration/sf1490) uses the IDWS Binding (OIO IDWS SOAP profile) and is called directly, i.e. not via Serviceplatformen. The signing of the SOAP Envelope content has been simplified with OIOIDWS. The examples demonstrate how both security profiles can be used in the same context. Read more at [Digitaliseringskataloget](https://digitaliseringskataloget.dk/tekniske_betingelser/adgangsstyring-systemer)
 
 [Chapter 4](#4-code-examples) describes the code examples in more detail.
 


### PR DESCRIPTION
Altered README so Sags- & Dokumentindeks and Ydelsesindeks reflect using the IDWS Binding (OIO IDWS SOAP profile) and is now called directly

Further added info regarding internal KOMBIT developed validation tool